### PR TITLE
updates after notes 20260706

### DIFF
--- a/nibs-bids-v6/examples/v.6.3/README.md
+++ b/nibs-bids-v6/examples/v.6.3/README.md
@@ -56,6 +56,9 @@ A row of `*_events.tsv` ties the two together by naming a temporal parameter set
 | Linkage keys | Plain identifiers | Cross-file keys prefixed with `nibs_` (`nibs_event_id`, `nibs_position_id`, `nibs_element_id`) |
 | Numeric typing | Many `integer` fields | `number` (decimals allowed) |
 | Received dose | Discussed alongside applied dose | Stores the applied dose; the in-tissue field is left to modelling |
+| Peripheral nerve stimulation | Not treated as a separate modality; described through TMS, TES, or TUS | `PNS` is a `nibs_type` value, with the underlying technology and the stimulated nerve described in `*_markers.tsv` |
+| Response fields | `motor_response`, `latency`, and `response_channel_*` columns in `*_nibs.tsv` | Removed; the evoked response and its channels belong to the recording modality and are linked through `nibs_event_id` |
+| Position without coordinates | Implicit | Explicitly supported through `position_label`, tape `HeadMeasurements`, and `position_description`, with the `element_*` columns set to `n/a` |
 | Modality interoperability | Implicit | Stated explicitly for any concurrent or related recording modality, including iEEG, single-unit, and LFP |
 
 ---

--- a/nibs-bids-v6/examples/v.6.3/README.md
+++ b/nibs-bids-v6/examples/v.6.3/README.md
@@ -1,13 +1,3 @@
-notes 20260706
-- make clearer the distinction between temporal info in nibs.tsv and spatial info in marker.tsv (double check)
-- make tables only for TSV stuff. definition not in a table. (basically like in any other BIDS specification)
-- move event file description further up (as it links with others, so might be logically better to have it up).
-- postion: first describe the position of the element (we are describing primarly the postion of the coil/trnsudcer on the head), and furhter down descrive optionally the cpostion of the target (which is not the primary focus here).
-- postion: how to reconstruct the postion matrix (4 x 4 , with row and cols that are 0s 3 x3 ) from this specificaion and vice versa? make sure that is clear. look at one of the eralier versions we had that transformation matrix ? we have to resolve this https://simnibs.github.io/simnibs/build/html/documentation/sim_struct/position.html . 3 rows, coodinate for the 3 coil (element) axis. the center of the element is the last column 
-- postion: collapse coil/transducer/electrod center to element centre.
-- postion: we need to be able to describ postion with "less" tecnical ways like: for TMS using elec postions or head measurament made with tape ruler (nasion, inion, etc.. ), but maybe we alredy ahve a text description? 
-
-
 # NIBS-BIDS proposal v6.3
 
 This document describes a structure for organizing **non-invasive brain stimulation (NIBS)**
@@ -35,6 +25,16 @@ The physical stimulus that actually reaches the target tissue (i.e., the **recei
 
 A central design goal of NIBS-BIDS is that the recorded metadata are sufficient to support such modelling. Although this specification describes the delivered stimulation rather than the received in-tissue stimulus, the recorded fields are selected so that, together with participant anatomy, they provide the information required to compute the physical stimulus within the brain. Consequently, datasets conforming to this specification can be used directly with modelling tools (e.g., SimNIBS or k-Wave) to estimate the in-tissue stimulus. The same principle also supports reproducibility: another researcher should be able to reconstruct the delivered stimulation and model the resulting in-tissue stimulus from the dataset alone (Peterchev et al., 2012).
 
+### Where each category is recorded
+
+The two categories map onto separate files, and this separation is the organizing principle of the whole structure.
+
+**Temporal parameters are recorded in `*_nibs.tsv`.** This file holds the waveform of the base stimulus and the way stimuli are grouped and repeated over time. It contains no spatial information.
+
+**Spatial parameters are recorded in `*_markers.tsv` and `*_nibs.json`.** The position and orientation of each stimulation element on the head are given in `*_markers.tsv`, expressed in the coordinate system declared in `*_coordsystem.json`. The geometry, size, and physical properties of the element, which are properties of the hardware rather than of a placement, are given in the `ElementSet` block of `*_nibs.json`.
+
+A row of `*_events.tsv` ties the two together by naming a temporal parameter set and a position for one delivery.
+
 ---
 
 ## What changed from v6.2
@@ -48,9 +48,11 @@ A central design goal of NIBS-BIDS is that the recorded metadata are sufficient 
 | Device hardware | `CoilSet` / `ElectrodeSet` / `TransducerSet`, referenced by `coil_id` / `electrode_id` / `transducer_id` | Unified **`ElementSet`** (`ElementType`: coil/electrode/transducer) and **`StimulatorSet`**, referenced by `nibs_element_id` and `stimulator_id` |
 | Multi-element events | Multiple rows indexed by `event_part` | A single row using the **`|` delimiter** in `nibs_element_id` and `stimulus_intensity`, or one row per element |
 | Spatial link | `target_id` column in `*_nibs.tsv` | `nibs_position_id` in `*_events.tsv`; `*_markers.tsv` also carries `nibs_element_id` |
+| What a position describes | Coordinates conflated the stimulation target and the element site | The **element position** is primary; the **target** is optional and secondary |
+| Element pose | Separate `coil_*` / `transducer_*` centres plus `normal_*`, `direction_*`, `beam_*` vectors | One **element centre** plus three **element axes**, from which the 4x4 pose matrix is assembled |
 | Dosing | `threshold_*` columns | `intensity_reference` and `intensity_scaling` columns plus an **`IntensitySet`** block in `*_nibs.json` |
 | Shape parameters | Nested under `Levels` in `*_nibs.json` | Their own `*_nibs.tsv` columns (`first_inflection`, `current_direction`, `ramp_up`/`ramp_down`, `frequency`, `starting_phase`, …) |
-| Coil current direction | Not specified | `current_direction` column with a defined reference frame |
+| Coil current direction | Not specified | `current_direction` column with a defined viewing frame and a closed set of codes |
 | Linkage keys | Plain identifiers | Cross-file keys prefixed with `nibs_` (`nibs_event_id`, `nibs_position_id`, `nibs_element_id`) |
 | Numeric typing | Many `integer` fields | `number` (decimals allowed) |
 | Received dose | Discussed alongside applied dose | Stores the applied dose; the in-tissue field is left to modelling |
@@ -87,9 +89,8 @@ sub-<label>/
 ```
 
 `*_events.tsv` is placed in `nibs/` when the stimulation is standalone or offline. When NIBS is
-concurrent with a recording, the timeline lives with that recording instead (see "Timeline and
-cross-modality interoperability"). Optional `*_headshape.<ext>` and `*_photo.<ext>` files are described
-under "Optional files".
+concurrent with a recording, the timeline lives with that recording instead. Optional
+`*_headshape.<ext>` and `*_photo.<ext>` files are described under "Optional files".
 
 ---
 
@@ -97,33 +98,32 @@ under "Optional files".
 
 | File | Role |
 |---|---|
-| `*_nibs.tsv` | Central table. One row per unique stimulation parameter set ("event type"). Holds the parameter values. |
-| `*_nibs.json` | Sidecar. Column descriptions, units, and levels, together with structured metadata (`StimulatorSet`, `ElementSet`, `IntensitySet`, `NavigationSystem`). |
-| `*_markers.tsv` (+ `.json`) | Spatial positions, one point or contact per row, referenced by `nibs_position_id` from `*_events.tsv`. |
+| `*_events.tsv` (+ `.json`) | Timeline. One row per delivery, naming a parameter set and a position. Used for synchronization across modalities. |
+| `*_nibs.tsv` (+ `.json`) | Temporal parameters. One row per unique stimulation parameter set. The sidecar also holds the device, intensity, and navigation metadata. |
+| `*_markers.tsv` (+ `.json`) | Spatial parameters. One row per element position. |
 | `*_coordsystem.json` | Coordinate system, fiducials, and anatomical landmarks for the positions in `*_markers.tsv`. |
-| `*_events.tsv` (+ `.json`) | Primary timeline (`onset`, `duration`, `nibs_event_id`, `nibs_position_id`) used for synchronization. |
 
-The `*_nibs.tsv` table carries the values that change from one protocol to the next. The `*_nibs.json`
-sidecar carries what is fixed or descriptive, namely what each column means, the unit of every numeric
+The TSV files carry the values that change from one protocol or placement to the next. The JSON
+sidecars carry what is fixed or descriptive, namely what each column means, the unit of every numeric
 column, and the full description of the devices and intensity references. Units are always stated in the
 sidecar and are never assumed from the numbers in the table.
 
 ### Linking identifiers
 
-Five identifiers connect the files. Each one is defined in a single place and referenced from elsewhere,
-so that device, intensity, and spatial information is written once and reused across many events.
+Five identifiers connect the files. Each is defined in a single place and referenced from elsewhere, so
+that device, intensity, and spatial information is written once and reused across many deliveries.
 
-`nibs_event_id` connects a row of `*_nibs.tsv` to one or more onsets in `*_events.tsv`. A parameter set
-is defined once in `*_nibs.tsv`, where `nibs_event_id` MUST be unique, and can be referenced many times
-in `*_events.tsv`, once for every time the protocol was delivered. `nibs_event_id` is the key used to
-synchronize stimulation with any other modality on the shared timeline.
+`nibs_event_id` connects a row of `*_events.tsv` to a row of `*_nibs.tsv`. A parameter set is defined
+once in `*_nibs.tsv`, where `nibs_event_id` MUST be unique, and can be referenced many times in
+`*_events.tsv`, once for every time that protocol was delivered. This is the key used to synchronize
+stimulation with any other modality on the shared timeline.
 
 `nibs_position_id` connects a row of `*_events.tsv` to one or more rows of `*_markers.tsv`. Each row of
-`*_markers.tsv` describes one point or contact and carries a unique `nibs_position_id`. When several
-elements are active in one event, `nibs_position_id` is `|`-delimited, one position per element, in the
-same order as `nibs_element_id`.
+`*_markers.tsv` describes one element placement and carries a unique `nibs_position_id`. When several
+elements are active in one delivery, `nibs_position_id` is `|`-delimited, one position per element, in
+the same order as `nibs_element_id`.
 
-`nibs_element_id` connects a row of `*_nibs.tsv` (and the matching position in `*_markers.tsv`) to an
+`nibs_element_id` connects a row of `*_nibs.tsv`, and the matching placement in `*_markers.tsv`, to an
 `ElementSet.ElementID` entry in `*_nibs.json`, which describes the physical element that delivers the
 stimulation. Several simultaneous elements, such as the two electrodes of a tES montage or two coils,
 are listed in one cell separated by `|`. The same element definition can be reused across many rows.
@@ -132,139 +132,170 @@ are listed in one cell separated by `|`. The same element definition can be reus
 which describes the device that generates the stimulus waveform.
 
 `intensity_reference` connects a row of `*_nibs.tsv` to an `IntensitySet.IntensityID` entry in
-`*_nibs.json`, which describes the reference used to set the intensity (for example a resting motor
-threshold) and its measured value.
+`*_nibs.json`, which describes the reference used to set the intensity, for example a resting motor
+threshold, together with its measured value.
 
 **Delimiter rule.** Whenever `|` is used in a column, the delimiter MUST be declared for that column in
-`*_nibs.json`, for example `{"nibs_element_id": {"Delimiter": "|"}}`. The values in `|`-delimited columns
-of the same row are aligned position by position.
+the corresponding sidecar, for example `{"nibs_element_id": {"Delimiter": "|"}}`. The values in
+`|`-delimited columns of the same row are aligned position by position.
 
-### How `*_events.tsv`, `*_nibs.tsv`, and `*_markers.tsv` relate
-
-`*_nibs.tsv` is a catalogue of stimulation protocols. Each row defines one complete protocol and is
-named by its `nibs_event_id`. `*_markers.tsv` is a catalogue of positions, one per row, named by
-`nibs_position_id`. `*_events.tsv` is the timeline of what happened, and it refers to a protocol by
-`nibs_event_id` and to a position by `nibs_position_id`. A given `nibs_event_id` appears once in
-`*_nibs.tsv` and usually many times in `*_events.tsv`, each occurrence with its own `onset`. To read a
-dataset, take a row of `*_events.tsv`, follow its `nibs_event_id` to the parameters in `*_nibs.tsv`, and
-follow its `nibs_position_id` to the location or locations in `*_markers.tsv`.
+To read a dataset, take a row of `*_events.tsv`, follow its `nibs_event_id` to the temporal parameters in
+`*_nibs.tsv`, and follow its `nibs_position_id` to the placement or placements in `*_markers.tsv`.
 
 ---
 
-## `*_nibs.tsv` (stimulation parameters)
+## `*_events.tsv` / `*_events.json` (timeline)
 
-Each row represents one logical stimulation event type with a unique set of parameters. A row may
-describe a single stimulus, or repeating and nested stimuli described parametrically with the
-`pattern<index>_*` fields. All fields are OPTIONAL unless stated otherwise, and numeric fields are typed
-`number`. Units for every numeric column MUST be declared in `*_nibs.json`.
+`*_events.tsv` is the timeline of what happened and the point at which stimulation is synchronized with
+every other modality. It is described first because it references both of the other tables.
+
+| Column | Requirement | Type | Description |
+|---|---|---|---|
+| `onset` | REQUIRED | number | Onset of the delivery, in seconds, relative to the start of the recording or of the stimulation block. |
+| `duration` | REQUIRED | number | Duration of the delivery in seconds, or `n/a` if not applicable. May be derived from the `pattern<index>_*` fields of the referenced `*_nibs.tsv` row. |
+| `nibs_event_id` | REQUIRED | string | References `nibs_event_id` in `*_nibs.tsv`, giving the temporal parameters of this delivery. |
+| `nibs_position_id` | OPTIONAL | string | References `nibs_position_id` in `*_markers.tsv`, giving the position of the element or elements. May be `\|`-delimited, one position per element, in the same order as `nibs_element_id`. |
+
+A given `nibs_event_id` appears once in `*_nibs.tsv` and usually many times in `*_events.tsv`, each
+occurrence with its own `onset`. The same protocol delivered at a different position is a new row of
+`*_events.tsv` with a different `nibs_position_id`, not a new row of `*_nibs.tsv`.
+
+### Concurrent and offline stimulation
+
+When NIBS is concurrent with a recorded modality, the timeline lives with that modality's
+`*_events.tsv`, and `*_nibs.json` points to it through `IntendedFor`. When NIBS is offline, meaning not
+concurrent with a recording, for example an fMRI run followed by tDCS followed by an fMRI run, or a
+behavioural block followed by TMS followed by a behavioural block, `*_events.tsv` is placed in `nibs/`,
+and the `*_nibs.tsv` is listed in `scans.tsv` between the surrounding recordings to mark the offline
+stimulation block.
+
+### Cross-modality interoperability
+
+Because synchronization is carried entirely by shared event information, NIBS-BIDS is compatible with any
+concurrent or related recording modality that BIDS already describes. This includes EEG, MEG, fMRI, EMG,
+behavioural data, and intracranial electrophysiology such as iEEG, single-unit, and LFP recordings, when
+the stimulation itself is non-invasive. The recording modality is stored in its own BIDS datatype, and
+its `*_events.tsv` carries the same `nibs_event_id` values, so no NIBS-specific mechanism is required to
+combine stimulation with a recording. The modalities named in this document and in the examples are
+illustrative and are not a limit on compatibility.
+
+---
+
+## `*_nibs.tsv` (temporal parameters)
+
+Each row represents one stimulation parameter set, identified by `nibs_event_id`. A row may describe a
+single stimulus, or repeating and nested stimuli described parametrically with the `pattern<index>_*`
+fields. Numeric fields are typed `number`, and units for every numeric column MUST be declared in
+`*_nibs.json`.
 
 One row holds a complete protocol, however long or repetitive it is. Rather than writing one row for
 every delivered stimulus, repetition over time is described with the `pattern<index>` fields, which
 record how the base stimulus is grouped and repeated. A single pulse, a paired pulse, a theta burst
 train, and a twenty minute tACS block are each a single row. Distinct parameter sets are distinct rows,
 so a paired-pulse recovery curve measured at five inter-stimulus intervals is five rows, one per ISI.
-This keeps the table compact and makes the structure of a protocol explicit instead of leaving it
-implicit in a long list of timestamps.
+This file contains no spatial information; the position of the element is given in `*_markers.tsv`.
 
-### General fields
+| Column | Requirement | Type | Description |
+|---|---|---|---|
+| `nibs_event_id` | REQUIRED | string | Identifier of a stimulation parameter set. Referenced from `*_events.tsv`. MUST be unique within the file. |
+| `nibs_type` | REQUIRED | string | Stimulation modality. One of `TMS`, `tES`, `TUS`, `PNS`. PNS uses whichever physical technology applies, and the stimulated nerve is described in `*_markers.tsv`. |
+| `stimulator_id` | RECOMMENDED | string | Device that generates the stimulus waveform. References `StimulatorSet.StimulatorID` in `*_nibs.json`. |
+| `nibs_element_id` | RECOMMENDED | string | Element that delivers the stimulation. References `ElementSet.ElementID` in `*_nibs.json`. Multiple simultaneous elements are separated by `\|` (e.g. `elec_1\|elec_2`). |
+| `stimulus_shape` | RECOMMENDED | string | Waveform shape of the base stimulus, from the closed vocabulary in "Stimulus shape vocabulary". |
+| `stimulus_intensity` | RECOMMENDED | number | Delivered amplitude of the base stimulus. Units are modality-dependent and declared in `*_nibs.json`. With multiple elements, one value per element separated by `\|` (e.g. `1\|-1`); for `tES` the delimited values MUST sum to 0. Set to `n/a` when per-stimulus intensities are given in `pattern1_intensity`. |
+| `stimulus_duration` | RECOMMENDED | number | Duration of the base stimulus, the time during which contiguous non-zero current or energy is delivered. |
+| `first_inflection` | OPTIONAL | string | (TMS) Direction of the first deflection of the induced current, `rising` or `descending`, corresponding to the normal or reverse setting on the stimulator. |
+| `current_direction` | OPTIONAL | string | (TMS) Direction of current flow in the coil winding. One of `cl`, `co`, `cl-co`, `co-cl`, `other`. See "Coil current direction". |
+| `ramp_up` | OPTIONAL | number | (`Rectangle`) Duration of the linear current ramp at the start of the block. |
+| `ramp_down` | OPTIONAL | number | (`Rectangle`) Duration of the linear current ramp at the end of the block. |
+| `frequency` | OPTIONAL | number | (`Sinusoid`) Oscillation frequency for tACS, or carrier frequency for TUS. |
+| `starting_phase` | OPTIONAL | number | (`Sinusoid`) Starting phase in degrees. May be `\|`-delimited and aligned with `nibs_element_id` for phase-shifted or anti-phase tACS. |
+| `offset` | OPTIONAL | number | (`Sinusoid`) Constant component added to the oscillation. |
+| `noise_type` | OPTIONAL | string | (`Noise`) Spectral character of the noise, for example `white` or `pink`. |
+| `frequency_low` | OPTIONAL | number | (`Noise`) Lower bound of the randomized band. |
+| `frequency_high` | OPTIONAL | number | (`Noise`) Upper bound of the randomized band. |
+| `distribution` | OPTIONAL | string | (`Noise`) Amplitude distribution, for example `gaussian`. |
+| `stimulus_description` | OPTIONAL | string | (`Custom`) Free-text description of a waveform not covered by the vocabulary. |
+| `pattern<index>_count` | OPTIONAL | number | Number of `pattern<index-1>` units in one `pattern<index>`. For `pattern1`, the number of base stimuli. |
+| `pattern<index>_interval` | OPTIONAL | number | Onset-to-onset interval between consecutive `pattern<index-1>` units. |
+| `pattern<index>_frequency` | OPTIONAL | number | Repetition frequency of the layer, equal to 1 / `pattern<index>_interval` in seconds. Provide `interval` or `frequency`. |
+| `pattern<index>_duration` | OPTIONAL | number | Total duration of the layer, including the interval after the final unit. |
+| `pattern<index>_intensity` | OPTIONAL | number | Per-unit intensities when intensity changes across units in the layer. Values separated by `\|`, with length equal to `pattern<index>_count`. When used at `pattern1`, set `stimulus_intensity = n/a`. |
+| `intensity_reference` | OPTIONAL | string | Anchor used to set the intensity. One of `rMT`, `aMT`, `1mV`, `e-field`, `absolute`. References `IntensitySet.IntensityID` in `*_nibs.json`. |
+| `intensity_scaling` | OPTIONAL | number or string | Multiplier applied to the reference value, for example `0.8` for 80% of the reference, or `absolute` for a directly specified value. |
+| `stimulus_count` | OPTIONAL | number | Counter of deliveries of the same parameter set to the same position within the file. For counting only, and MUST NOT be used for synchronization. |
+| `stimulus_validation` | OPTIONAL | string | Whether delivery or positioning was verified. One of `verified`, `observed`, `not_verified`, `unknown`. |
+| `subject_feedback` | OPTIONAL | string | Participant-reported perception or discomfort. |
+| `status` | OPTIONAL | string | Data-quality flag for the row. |
+| `status_description` | OPTIONAL | string | Free-text explanation of `status`. |
+| `timestamp` | OPTIONAL | string | ISO 8601 time at which the stimulation occurred or was logged. |
+| `electric_field_target` | OPTIONAL | number | (TMS) Electric field at the target, as reported or modelled by the device or navigation system. |
+| `electric_field_max` | OPTIONAL | number | (TMS) Peak electric field, as reported or modelled. |
+| `electric_field_units` | OPTIONAL | string | Units for the electric-field values, recommended `V/m`. |
+| `electric_field_model_name` | OPTIONAL | string | Source model or system for the electric-field values. |
+| `electric_field_model_version` | OPTIONAL | string | Version of that model or system. |
+| `contact_impedance` | OPTIONAL | number | (tES) Measured contact impedance, one value per element when `\|`-delimited. |
+| `measured_current_intensity` | OPTIONAL | number | (tES) Device-reported delivered current. |
+| `measured_voltage_intensity` | OPTIONAL | number | (tES) Device-reported delivered voltage. |
+| `current_statistics` | OPTIONAL | string | (tES) Device summary statistics for the delivered current. |
+| `measured_peak_negative_pressure` | OPTIONAL | number | (TUS) Estimated or measured peak negative pressure. |
+| `spatial_peak_pulse_average_intensity` | OPTIONAL | number | (TUS) ISPPA for the delivered stimulation. |
+| `spatial_peak_temporal_average_intensity` | OPTIONAL | number | (TUS) ISPTA for the delivered stimulation. |
+| `mechanical_index` | OPTIONAL | number | (TUS) Mechanical Index. |
+| `thermal_index` | OPTIONAL | number | (TUS) Thermal Index. |
 
-| Field | Type | Description |
-|---|---|---|
-| `nibs_event_id` | string | Identifier of a stimulation event type with unique parameters. May describe a single stimulus or repeating and nested stimuli. Links to `*_events.tsv`. MUST be unique within the file. |
-| `nibs_type` | string | Stimulation modality. One of `TMS`, `tES`, `TUS`, `PNS`. PNS uses whichever physical technology applies (TMS, TES, or TUS), and the stimulated nerve is described through `position_*` in `*_markers.tsv`. |
-| `stimulator_id` | string | Label of the device that generates the stimulus waveform. Links to `StimulatorSet.StimulatorID` in `*_nibs.json`. |
-| `nibs_element_id` | string | Label of the element that delivers stimulation (coil, electrode, or transducer). Links to `ElementSet.ElementID`. Multiple simultaneous elements are separated by `\|` (e.g. `elec_1\|elec_2`), with the delimiter declared in `*_nibs.json`. |
-
-The spatial target is not a `*_nibs.tsv` column. It is given as `nibs_position_id` in `*_events.tsv`, so
-the same protocol delivered at different positions does not need a new row.
-
-### Stimulus fields (the base unit)
-
-| Field | Type | Description |
-|---|---|---|
-| `stimulus_shape` | string | Shape of the base stimulus, taken from the closed vocabulary in "Stimulus shape vocabulary". Shape-specific parameters are given as their own `*_nibs.tsv` columns. |
-| `stimulus_intensity` | number | Delivered amplitude of the base stimulus. Units are modality-dependent and declared in `*_nibs.json` (for example `% Maximum Stimulator Output` for TMS, `mA` for tES). Where multiple elements are listed in `nibs_element_id`, one value per element separated by `\|` (e.g. `1\|-1`); for tES the delimited values MUST sum to 0. Set to `n/a` when per-stimulus intensities are given instead in `pattern1_intensity`. How the amplitude was chosen is recorded in `intensity_reference` and `intensity_scaling`. |
-| `stimulus_duration` | number | Duration of the base stimulus, meaning the time during which contiguous non-zero current or energy is delivered. Units declared in `*_nibs.json`. |
-| `current_direction` | string | (TMS) Direction of current flow in the coil winding. See "Stimulus shape vocabulary". |
-| `first_inflection` | string | (TMS) Direction of the first deflection of the induced current. See "Stimulus shape vocabulary". |
+The columns from `stimulus_count` onward hold values reported or computed by the stimulation device or
+the navigation system rather than experimenter-set parameters. The evoked response itself, for example
+an EMG MEP or an EEG TEP, belongs to the concurrent recording modality and is linked through
+`nibs_event_id` rather than duplicated here.
 
 ### Stimulus shape vocabulary
 
 `stimulus_shape` uses a closed vocabulary, meaning a fixed set of allowed values rather than free text.
-The allowed values, and the modality each applies to, are listed below. `Custom` is available for any
-waveform not covered and requires a free-text description.
+`Custom` is available for any waveform not covered and requires a free-text `stimulus_description`.
+`Monophasic`, `Biphasic`, and `Halfsine` apply to TMS; `Rectangle`, `Sinusoid`, and `Noise` apply to tES;
+`Sinusoid` applies to TUS; `Custom` applies to any modality.
 
-| `nibs_type` | Allowed `stimulus_shape` |
-|---|---|
-| TMS | `Monophasic`, `Biphasic`, `Halfsine` |
-| tES | `Rectangle`, `Sinusoid`, `Noise` |
-| TUS | `Sinusoid` |
-| any | `Custom` |
-
-Each shape carries its own parameters as `*_nibs.tsv` columns. In the sidecar, `Levels` holds only the
-value-to-description text for `stimulus_shape`, following the usual BIDS convention.
-
-| Shape | Parameter columns in `*_nibs.tsv` |
-|---|---|
-| `Monophasic`, `Biphasic`, `Halfsine` | `first_inflection` (`rising` or `descending`), the direction of the first deflection of the induced current, which corresponds to the normal or reverse current-direction setting on the stimulator; and `current_direction` (`cl`, `co`, `cl-co`, `co-cl`, `other`), defined below. |
-| `Rectangle` | `ramp_up` and `ramp_down` (s), the durations of the linear ramps at the start and end of the block. |
-| `Sinusoid` | `frequency` (Hz for tACS, carrier frequency for TUS), `starting_phase` (degrees), and an optional `offset` adding a constant component. |
-| `Noise` | `noise_type` (`white`, `pink`, or other), `frequency_low` and `frequency_high` (Hz) bounding the randomized band, and an optional `distribution` (for example `gaussian`). |
-| `Custom` | `stimulus_description` (free text), for any waveform not listed above. |
-
-A 10 Hz tACS sinusoid is one `*_nibs.tsv` row carrying `stimulus_shape = Sinusoid`, `frequency = 10`,
-`starting_phase = 0`. Shape-parameter columns are only needed for the shapes a dataset uses, so the
-table stays narrow. For anti-phase or phase-shifted tACS, `starting_phase` may be a `|`-delimited vector
-aligned with `nibs_element_id`.
-
-**Coil current direction.** `current_direction` records the direction of current flow in the coil
-winding. This can change between stimulations and affects the induced field, so it is given per row. It
-is read in a fixed viewing frame. Hold the coil with its stimulating face, the face placed against the
-head, pointing away from you, and its top face toward you. Then turn the coil so that the handle, or
-leading edge, points away from you. This is the orientation in which the coil sits on the manufacturer
-calibration block. Looking at the top face in this orientation, report the direction of current flow in
-each wing using the codes below.
-
-| Value | Coil | Meaning |
-|---|---|---|
-| `cl` | circular | single winding, current clockwise |
-| `co` | circular | single winding, current counterclockwise |
-| `cl-co` | figure-of-eight | left wing clockwise, right wing counterclockwise |
-| `co-cl` | figure-of-eight | left wing counterclockwise, right wing clockwise |
-| `other` | any other geometry | current flow not captured by the codes above, described in free text in `*_nibs.json` |
-
-When a row drives more than one coil, `current_direction` is `|`-delimited and aligned to
-`nibs_element_id`, one code per coil. For a coil that is neither circular nor figure-of-eight, use
-`other` and describe the actual current flow in the `current_direction` entry of `*_nibs.json`, under
-`Levels.other`.
+Each shape carries its own parameter columns, listed in the table above. `Monophasic`, `Biphasic`, and
+`Halfsine` use `first_inflection` and `current_direction`. `Rectangle` uses `ramp_up` and `ramp_down`.
+`Sinusoid` uses `frequency`, `starting_phase`, and `offset`. `Noise` uses `noise_type`,
+`frequency_low`, `frequency_high`, and `distribution`. In the sidecar, `Levels` holds only the
+value-to-description text for `stimulus_shape`, following the usual BIDS convention. Shape-parameter
+columns are only needed for the shapes a dataset actually uses, so the table stays narrow. A 10 Hz tACS
+sinusoid is one row carrying `stimulus_shape = Sinusoid`, `frequency = 10`, and `starting_phase = 0`.
 
 These vocabularies (`nibs_type`, `stimulus_shape`, `first_inflection`, `current_direction`,
 `intensity_reference`) are deliberately finite. A small, fixed set of terms can be compiled into a
 partnered HED (Hierarchical Event Descriptors) library schema, so the low-level building blocks of a
-protocol can be tagged consistently and searched across datasets (see the HED appendix in the BIDS
-specification). Full NIBS protocols are too variable to standardize directly, so only the building
-blocks are aligned to HED.
+protocol can be tagged consistently and searched across datasets. Full NIBS protocols are too variable to
+standardize directly, so only the building blocks are aligned to HED.
 
-### Repeating and nested stimuli (`pattern<index>_*`)
+### Coil current direction
+
+`current_direction` records the direction of current flow in the coil winding. This can change between
+stimulations and affects the induced field, so it is given per row. It is read in a fixed viewing frame.
+Hold the coil with its stimulating face, the face placed against the head, pointing away from you, and
+its top face toward you. Then turn the coil so that the handle, or leading edge, points away from you.
+This is the orientation in which the coil sits on the manufacturer calibration block. Looking at the top
+face in this orientation, report the direction of current flow in each wing. `cl` and `co` describe a
+circular coil with a single winding, clockwise and counterclockwise respectively. `cl-co` and `co-cl`
+describe a figure-of-eight coil and name the left wing then the right wing. `other` covers any geometry
+not captured by these codes, with the current flow described in free text under `Levels.other` in
+`*_nibs.json`. When a row drives more than one coil, `current_direction` is `|`-delimited and aligned to
+`nibs_element_id`, one code per coil.
+
+### Repeating and nested stimuli
 
 Repetition is described by stacked pattern layers. `pattern1` repeats the base stimulus, `pattern2`
 repeats `pattern1`, and in general `pattern<index>` repeats `pattern<index-1>`. The scheme nests to
 arbitrary depth without new field names.
 
-| Field | Type | Description |
-|---|---|---|
-| `pattern<index>_count` | number | Number of `pattern<index-1>` units in one `pattern<index>` (for `pattern1`, the number of base stimuli). |
-| `pattern<index>_interval` | number | Onset-to-onset interval between consecutive `pattern<index-1>` units. Units declared in `*_nibs.json`. |
-| `pattern<index>_frequency` | number | Repetition frequency, equal to 1 / `pattern<index>_interval` (in s). Provide `interval` or `frequency`. |
-| `pattern<index>_duration` | number | Total duration of the layer, including the interval after the final unit. |
-| `pattern<index>_intensity` | number | Per-unit intensities when intensity changes across units in the layer. Values separated by `\|`, with length equal to `pattern<index>_count`. When used at `pattern1`, set `stimulus_intensity = n/a`. |
-
 Consistency rules, evaluated with all times in seconds, are `pattern<index>_frequency = 1 /
 pattern<index>_interval` and `pattern<index>_duration = pattern<index>_count × pattern<index>_interval`.
 A layer SHOULD provide `count` plus one of `interval` or `frequency`, from which `duration` is derivable.
-Any two of `count`, `interval`/`frequency`, and `duration` are sufficient, and the third can be derived.
-Per-column units are free and declared in the JSON, but the two equations assume seconds, so tools that
-convert between layers should normalize to seconds first.
+Any two of `count`, `interval` or `frequency`, and `duration` are sufficient, and the third can be
+derived. Per-column units are free and declared in the JSON, but the two equations assume seconds, so
+tools that convert between layers should normalize to seconds first.
 
 ### Changing intensity across repeats and across elements
 
@@ -286,274 +317,253 @@ the `|`-separated intensities ambiguous as to which element they belong to.
 
 ### Intensity reference and scaling
 
-`stimulus_intensity` and `pattern<index>_intensity` hold the amplitude that was delivered. Two optional
-columns record how that amplitude was chosen. Both may be `|`-delimited and are aligned to the intensity
-values they describe.
-
-| Field | Type | Description |
-|---|---|---|
-| `intensity_reference` | string | Anchor used to set the intensity, from the closed vocabulary `rMT`, `aMT`, `1mV`, `e-field`, `absolute`. Links to `IntensitySet.IntensityID` in `*_nibs.json`. `absolute` denotes a directly specified value with no reference. |
-| `intensity_scaling` | number \| string | Multiplier applied to the reference value (for example `0.8` for 80% of the reference), or `absolute` for a directly specified value. |
+`stimulus_intensity` and `pattern<index>_intensity` hold the amplitude that was delivered.
+`intensity_reference` and `intensity_scaling` record how that amplitude was chosen. Both may be
+`|`-delimited and are aligned to the intensity values they describe.
 
 The measured value of the reference, for example a resting motor threshold of 50 % Maximum Stimulator
 Output, is not stored on every row. It is given once in the `IntensitySet` block of `*_nibs.json`. The
 delivered amplitude therefore equals `IntensitySet.Value × intensity_scaling`, except where
-`intensity_scaling` is `absolute`. When different pulses or elements use different references,
-`intensity_reference` and `intensity_scaling` are `|`-delimited and aligned to the intensity vector. For
-a SICI protocol where the conditioning pulse is dosed by resting motor threshold and the test pulse to a
-1 mV target, a row reads `pattern1_intensity = 35|58`, `intensity_reference = rMT|1mV`,
-`intensity_scaling = 0.7|1`. The vocabulary of references covers resting and active motor thresholds
-(`rMT`, `aMT`), so the long-standing need for a defined description of motor-threshold dosing is met by
-the combination of `intensity_reference` and the `IntensitySet` method fields.
+`intensity_scaling` is `absolute`. For a SICI protocol where the conditioning pulse is dosed by resting
+motor threshold and the test pulse to a 1 mV target, a row reads `pattern1_intensity = 35|58`,
+`intensity_reference = rMT|1mV`, and `intensity_scaling = 0.7|1`. The vocabulary covers resting and
+active motor thresholds, so motor-threshold dosing is fully described by the combination of
+`intensity_reference` and the `IntensitySet` method fields.
 
-### Optional reported and measured fields
+---
 
-These fields are OPTIONAL and hold values reported or computed by the stimulation device or the
-navigation system. They are not experimenter-set stimulation parameters. The evoked response itself
-(for example an EMG MEP or an EEG TEP) belongs to the concurrent recording modality and is linked through
-`nibs_event_id`, not duplicated here.
+## `*_markers.tsv` (spatial parameters)
 
-| Field | Type | Description |
-|---|---|---|
-| `stimulus_count` | number | Counter of deliveries of the same parameter set to the same position within the file. For counting only, and MUST NOT be used for synchronization. |
-| `stimulus_validation` | string | Whether delivery or positioning was verified (`verified`, `observed`, `not_verified`, `unknown`). |
-| `subject_feedback` | string | Participant-reported perception or discomfort. |
-| `status` / `status_description` | string | Data-quality flags for the row. |
-| `timestamp` | string | ISO 8601 time at which the stimulation occurred or was logged. |
+Each row describes the placement of one stimulation element, identified by `nibs_position_id` and
+referenced from `*_events.tsv`. The primary object described is the **element on the head**, meaning the
+coil, electrode, or transducer, through its centre and its orientation. The **target**, meaning the
+cortical site or acoustic focus that the placement is intended to reach, is optional and secondary,
+because it is an intention rather than a delivered parameter.
 
-For TMS, navigation systems may report a modelled or measured electric field at the target. These values
-are device or model outputs, not a substitute for downstream field modelling.
+Multi-element montages are represented as multiple rows, one per element. The corresponding
+`*_events.tsv` row references them through a `|`-delimited `nibs_position_id`, ordered to match
+`nibs_element_id`. The coordinate frame and units are defined in `*_coordsystem.json`.
 
-| Field | Type | Description |
-|---|---|---|
-| `electric_field_target` / `electric_field_max` | number | Electric field at the target and at its peak, as reported or modelled by the device or navigation system. |
-| `electric_field_units` | string | Units for the electric-field values (recommended `V/m`). |
-| `electric_field_model_name` / `electric_field_model_version` | string | Source model or system for the electric-field values. |
+| Column | Requirement | Type | Description |
+|---|---|---|---|
+| `nibs_position_id` | REQUIRED | string | Identifier of one element placement (one row). MUST be unique within the file. |
+| `nibs_element_id` | RECOMMENDED | string | Element placed at this position. References `ElementSet.ElementID` in `*_nibs.json`, the same key used in `*_nibs.tsv`. |
+| `position_label` | RECOMMENDED | string | Standardized label for the placement, for example the 10-20 or 10-10 site `C3`, or a site name such as `M1_hand` or `DLPFC`. |
+| `position_description` | OPTIONAL | string | Free-text description of the placement and how it was located. |
+| `position_group` | OPTIONAL | string | Organizational grouping label, for example montage membership. MUST NOT be used for linkage or synchronization. |
+| `element_centre_x` | RECOMMENDED | number | x coordinate of the centre of the element. |
+| `element_centre_y` | RECOMMENDED | number | y coordinate of the centre of the element. |
+| `element_centre_z` | RECOMMENDED | number | z coordinate of the centre of the element. |
+| `element_xdir_x` | OPTIONAL | number | x component of the element x axis. |
+| `element_xdir_y` | OPTIONAL | number | y component of the element x axis. |
+| `element_xdir_z` | OPTIONAL | number | z component of the element x axis. |
+| `element_ydir_x` | OPTIONAL | number | x component of the element y axis, which runs along the handle or leading edge. |
+| `element_ydir_y` | OPTIONAL | number | y component of the element y axis. |
+| `element_ydir_z` | OPTIONAL | number | z component of the element y axis. |
+| `element_zdir_x` | OPTIONAL | number | x component of the element z axis, which points from the element into the head. |
+| `element_zdir_y` | OPTIONAL | number | y component of the element z axis. |
+| `element_zdir_z` | OPTIONAL | number | z component of the element z axis. |
+| `element_distance` | OPTIONAL | number | Distance from the element surface to the scalp, for example the thickness of padding or hair. |
+| `target_x` | OPTIONAL | number | x coordinate of the intended target, for example a cortical site or an acoustic focus. |
+| `target_y` | OPTIONAL | number | y coordinate of the intended target. |
+| `target_z` | OPTIONAL | number | z coordinate of the intended target. |
+| `target_label` | OPTIONAL | string | Standardized label or anatomical name of the target. |
+| `peeling_depth` | OPTIONAL | number | Depth from the scalp or cortical surface to the target. |
+| `efield_max_x` | OPTIONAL | number | x coordinate of the location of maximum electric field, when modelled. |
+| `efield_max_y` | OPTIONAL | number | y coordinate of the location of maximum electric field. |
+| `efield_max_z` | OPTIONAL | number | z coordinate of the location of maximum electric field. |
 
-For tES, the device may report delivered current and contact quality.
+A `*_markers.json` sidecar describes these columns with their units and descriptions.
 
-| Field | Type | Description |
-|---|---|---|
-| `contact_impedance` | number | Measured contact impedance for the element (units declared, for example Ω or kΩ). |
-| `measured_current_intensity` / `measured_voltage_intensity` | number | Device-reported delivered amplitude. |
-| `current_statistics` | string | Device summary statistics for the delivered current. |
+### Element pose and the 4x4 matrix
 
-For TUS, the acoustic dose and the standard safety indices may be reported.
+The centre and the three axes together define the full pose of the element. They are stored as twelve
+plain numeric columns because BIDS tabular files hold a single string or number in each cell and provide
+no array or matrix type. A matrix therefore cannot be placed in a TSV column, and the twelve numbers are
+the canonical representation. The 4x4 affine matrix used by modelling tools is assembled from them.
 
-| Field | Type | Description |
-|---|---|---|
-| `measured_peak_negative_pressure` | number | Estimated or measured peak negative pressure. |
-| `spatial_peak_pulse_average_intensity` | number | ISPPA for the delivered stimulation. |
-| `spatial_peak_temporal_average_intensity` | number | ISPTA for the delivered stimulation. |
-| `mechanical_index` | number | Mechanical Index. |
-| `thermal_index` | number | Thermal Index. |
+```
+      | element_xdir_x   element_ydir_x   element_zdir_x   element_centre_x |
+  M = | element_xdir_y   element_ydir_y   element_zdir_y   element_centre_y |
+      | element_xdir_z   element_ydir_z   element_zdir_z   element_centre_z |
+      |       0                0                0                 1        |
+```
 
-The procedure-level motor-response fields and per-response channel fields used in earlier drafts
-(`motor_response`, `latency`, `response_channel_*`) are not part of this specification, because the
-response and its channels are described by the recording modality (for example EMG) and linked through
-`nibs_event_id`.
+The first three columns are the element x, y, and z axes, and the fourth column is the element centre.
+The bottom row is always `0 0 0 1`. The axes MUST be unit vectors, MUST be mutually orthogonal, and MUST
+form a right-handed system, so that `xdir = ydir × zdir`. The y axis runs along the handle or leading
+edge of the element, and the z axis points from the element into the head. This is the same convention
+as the SimNIBS `matsimnibs` matrix, so the assembled matrix can be used directly for modelling.
+
+The reverse operation is equally direct. Given a 4x4 matrix in this convention, the first column gives
+`element_xdir_x`, `element_xdir_y`, and `element_xdir_z`; the second column gives the `element_ydir_*`
+values; the third column gives the `element_zdir_*` values; and the fourth column gives the
+`element_centre_*` values. The bottom row is discarded.
+
+### Describing position without coordinates
+
+Coordinates are RECOMMENDED when neuronavigation or another tracking method was used, but a dataset may
+locate an element without them. Two alternatives are supported and may be combined.
+
+The first is a standardized label in `position_label`, for example the 10-20 or 10-10 site `C3`. This is
+the most common way to report tES montages and non-navigated TMS, and modelling tools accept it directly,
+since SimNIBS takes an EEG 10-10 electrode name in place of coil coordinates.
+
+The second is a set of head measurements taken with a tape from anatomical landmarks such as the nasion,
+the inion, and the left and right preauricular points. These are recorded in the `HeadMeasurements`
+field of `*_coordsystem.json`, with their units and a description of how they were obtained, and the
+procedure is summarized in `position_description`.
+
+When neither coordinates nor measurements are available, `position_label` and `position_description`
+alone are still a valid description of a placement, and the `element_*` columns are set to `n/a`.
 
 ---
 
 ## `*_nibs.json` (sidecar)
 
 A BIDS JSON sidecar that describes each `*_nibs.tsv` column (`LongName`, `Description`, `Units`,
-`Levels`, `Delimiter`) and carries structured device, intensity, and context metadata. Numeric columns
-SHOULD be documented as `number`.
+`Levels`, `Delimiter`) and carries structured device, intensity, and navigation metadata.
 
-Top-level descriptive fields include `NIBSDescription`, a free-text summary of the protocol;
-`ConcurrentModalities`, an array of concurrently recorded modalities (for example `["eeg"]`, `["emg"]`,
-`["ieeg"]`, `["none"]`); `IntendedFor`, a BIDS URI or array of URIs to the `*_events.tsv` or recording
-the stimulation is time-locked to; and task and institution context (`TaskName`, `TaskDescription`,
-`Instructions`, `InstitutionName`, `InstitutionAddress`, `InstitutionalDepartmentName`).
+| Field | Requirement | Type | Description |
+|---|---|---|---|
+| `NIBSDescription` | RECOMMENDED | string | Free-text summary of the protocol. |
+| `ConcurrentModalities` | RECOMMENDED | array | Concurrently recorded modalities, for example `["eeg"]`, `["emg"]`, `["ieeg"]`, or `["none"]`. |
+| `IntendedFor` | RECOMMENDED | string or array | BIDS URI or URIs to the `*_events.tsv` or recording the stimulation is time-locked to. |
+| `TaskName` | OPTIONAL | string | Name of the task during which stimulation was delivered. |
+| `TaskDescription` | OPTIONAL | string | Description of the task. |
+| `Instructions` | OPTIONAL | string | Instructions given to the participant. |
+| `InstitutionName` | OPTIONAL | string | Institution where the stimulation was performed. |
+| `InstitutionAddress` | OPTIONAL | string | Address of the institution. |
+| `InstitutionalDepartmentName` | OPTIONAL | string | Department within the institution. |
+| `StimulatorSet` | RECOMMENDED | object | Description of the waveform generator or generators. See below. |
+| `ElementSet` | RECOMMENDED | array | Description of the stimulation elements. See below. |
+| `IntensitySet` | OPTIONAL | array | Description of the intensity references. See below. |
+| `NavigationSystem` | OPTIONAL | object | Description of the navigation or positioning system. See below. |
 
 ### `StimulatorSet`
 
 Describes the device or devices that generate the stimulus waveform. Referenced from `stimulator_id`.
 
-| Field | Type | Description |
-|---|---|---|
-| `StimulatorID` | string | Unique id, referenced from `stimulator_id`. |
-| `Manufacturer` | string | Manufacturer name. |
-| `ManufacturerModelName` | string | Model name or number. |
-| `ManufacturerSerialNumber` | string | Serial number. |
-| `SoftwareVersion` | string | (Optional) Control-software version. |
+| Field | Requirement | Type | Description |
+|---|---|---|---|
+| `StimulatorID` | REQUIRED | string | Unique identifier, referenced from `stimulator_id`. |
+| `Manufacturer` | RECOMMENDED | string | Manufacturer name. |
+| `ManufacturerModelName` | RECOMMENDED | string | Model name or number. |
+| `ManufacturerSerialNumber` | OPTIONAL | string | Serial number. |
+| `SoftwareVersion` | OPTIONAL | string | Control-software version. |
 
 ### `ElementSet`
 
-An array of the elements that deliver stimulation. Each entry is referenced from `nibs_element_id`
-through `ElementID`. `ElementType` selects which type-specific properties apply.
+An array describing the elements that deliver stimulation. Each entry is referenced from
+`nibs_element_id` through `ElementID`. `ElementType` selects which type-specific fields apply. These are
+the spatial parameters that belong to the hardware rather than to a placement.
 
-| Field | Type | Description |
-|---|---|---|
-| `ElementID` | string | Unique id, referenced from `nibs_element_id`. |
-| `ElementType` | string | `coil`, `electrode`, or `transducer`. |
-| `ModelName` | string | Model name or number. |
-| `SerialNumber` | string | Serial number. |
-
-For `ElementType = coil` (TMS), additional fields are `CoilShape` (for example figure-of-eight,
-circular), `CoilCooling` (air, liquid, passive), `CoilDiameter` `{Value, Units, Description}`,
-`MagneticFieldPeak`, `MagneticFieldPenetrationDepth`, and `MagneticFieldGradient`.
-
-For `ElementType = electrode` (tES), additional fields are `ElectrodeRole` (REQUIRED, one of `anode`,
-`cathode`, `return`, `ground`, `other`), `Shape`, `Dimensions` or `ElectrodeArea` or `ElectrodeSize`,
-`Thickness`, `Material`, `ElectrodeContactMedium` (gel, saline, paste, dry), and `ElectrodePreparation`.
-
-For `ElementType = transducer` (TUS), additional fields are `TransducerType` (single-element,
-phased-array, planar, custom), `FocusType`, `CarrierFrequency`, `FocalDepth`, `ApertureDiameter`,
-`MaxPeakNegativePressure`, `MaxMechanicalIndex`, and `TransducerContactMedium`. Phased arrays add
-`NumberOfElements`, `ElementPitch`, and `ArrayGeometry`. Object-valued fields use
-`{Value, Units, Description}`.
+| Field | Requirement | Type | Description |
+|---|---|---|---|
+| `ElementID` | REQUIRED | string | Unique identifier, referenced from `nibs_element_id`. |
+| `ElementType` | REQUIRED | string | One of `coil`, `electrode`, `transducer`. |
+| `ModelName` | RECOMMENDED | string | Model name or number. |
+| `SerialNumber` | OPTIONAL | string | Serial number. |
+| `CoilShape` | RECOMMENDED for `coil` | string | Winding geometry, for example figure-of-eight or circular. |
+| `CoilCooling` | OPTIONAL for `coil` | string | Cooling method, for example air, liquid, or passive. |
+| `CoilDiameter` | OPTIONAL for `coil` | object | Wing or loop diameter as `{Value, Units, Description}`. |
+| `MagneticFieldPeak` | OPTIONAL for `coil` | object | Peak magnetic field. |
+| `MagneticFieldPenetrationDepth` | OPTIONAL for `coil` | object | Penetration depth. |
+| `MagneticFieldGradient` | OPTIONAL for `coil` | object | Field gradient. |
+| `ElectrodeRole` | REQUIRED for `electrode` | string | One of `anode`, `cathode`, `return`, `ground`, `other`. |
+| `Shape` | RECOMMENDED for `electrode` | string | Electrode shape. |
+| `ElectrodeSize` | RECOMMENDED for `electrode` | object | Size or area as `{Value, Units, Description}`. |
+| `Thickness` | OPTIONAL for `electrode` | object | Electrode thickness. |
+| `Material` | OPTIONAL for `electrode` | string | Conductive material. |
+| `ElectrodeContactMedium` | RECOMMENDED for `electrode` | string | Coupling medium, for example gel, saline, paste, or dry. |
+| `ElectrodePreparation` | OPTIONAL for `electrode` | string | Skin preparation procedure. |
+| `TransducerType` | RECOMMENDED for `transducer` | string | One of single-element, phased-array, planar, custom. |
+| `FocusType` | OPTIONAL for `transducer` | string | Focusing method. |
+| `CarrierFrequency` | RECOMMENDED for `transducer` | object | Carrier frequency. |
+| `FocalDepth` | RECOMMENDED for `transducer` | object | Focal depth. |
+| `ApertureDiameter` | OPTIONAL for `transducer` | object | Aperture diameter. |
+| `MaxPeakNegativePressure` | OPTIONAL for `transducer` | object | Maximum peak negative pressure. |
+| `MaxMechanicalIndex` | OPTIONAL for `transducer` | number | Maximum Mechanical Index. |
+| `TransducerContactMedium` | OPTIONAL for `transducer` | string | Coupling medium. |
+| `NumberOfElements` | OPTIONAL for phased arrays | number | Number of array elements. |
+| `ElementPitch` | OPTIONAL for phased arrays | object | Spacing between array elements. |
+| `ArrayGeometry` | OPTIONAL for phased arrays | string | Geometry of the array. |
 
 Two or more elements that act together, for example the two coils of a double-coil ccPAS montage, are
-listed as a `|`-delimited `nibs_element_id` (for example `Coil_1|Coil_2`) with one `ElementSet` entry
-each, or as separate `*_nibs.tsv` rows, one element per row.
+listed as a `|`-delimited `nibs_element_id` with one `ElementSet` entry each, or as separate `*_nibs.tsv`
+rows, one element per row.
 
 ### `IntensitySet`
 
-Describes each intensity reference named in `intensity_reference`, with one entry per reference.
+An array describing each intensity reference named in `intensity_reference`, with one entry per
+reference. `absolute` is a reserved value for directly specified intensities and needs no entry.
 
-| Field | Type | Description |
-|---|---|---|
-| `IntensityID` | string | Unique id, referenced from `intensity_reference`. |
-| `Value` | number | Measured value of the reference (for example the resting motor threshold). |
-| `Units` | string | Units of `Value` (for example `% Maximum Stimulator Output`, `mA`). |
-| `Type` | string | Reference endpoint, for example `resting_motor`, `active_motor`, `phosphene`, `sensation`, `pain`. |
-| `Criterion` | string | Criterion defining the reference (for example "1 mV MEP", "visible twitch", "perceptible phosphene"). |
-| `Algorithm` | string | Estimation procedure (for example "5/10", "PEST", staircase). |
-| `MeasurementMethod` | string | Modality used to assess the response (for example EMG MEP, visual report, behavioural). |
-
-`absolute` is a reserved `intensity_reference` value for directly specified intensities and needs no
-`IntensitySet` entry.
+| Field | Requirement | Type | Description |
+|---|---|---|---|
+| `IntensityID` | REQUIRED | string | Unique identifier, referenced from `intensity_reference`. |
+| `Value` | REQUIRED | number | Measured value of the reference, for example the resting motor threshold. |
+| `Units` | REQUIRED | string | Units of `Value`, for example `% Maximum Stimulator Output` or `mA`. |
+| `Type` | RECOMMENDED | string | Reference endpoint, for example `resting_motor`, `active_motor`, `phosphene`, `sensation`, `pain`. |
+| `Criterion` | RECOMMENDED | string | Criterion defining the reference, for example "1 mV MEP" or "perceptible phosphene". |
+| `Algorithm` | OPTIONAL | string | Estimation procedure, for example "5/10", "PEST", or a staircase. |
+| `MeasurementMethod` | OPTIONAL | string | Modality used to assess the response, for example EMG MEP or visual report. |
 
 ### `NavigationSystem`
 
-Optional, and RECOMMENDED when navigation, tracking, or robotic positioning is used.
+Describes the navigation, tracking, or robotic positioning system. RECOMMENDED whenever coordinates are
+given in `*_markers.tsv`.
 
-| Field | Type | Description |
-|---|---|---|
-| `Navigation` | boolean | Whether a navigation, tracking, or positioning system was used. |
-| `NavigationHardwareType` | string | For example `optical_tracking`, `robot`, `cobot`, `mechanical_arm`. |
-| `NavigationModelName` | string | Vendor or model. |
-| `NavigationSoftwareVersion` | string | Software version. |
-| `NavigationHardwareSerialNumber` | string | Serial or identifier. |
-| `NavigationNotes` | string | Setup notes (camera type, calibration, and so on). |
-
----
-
-## `*_markers.tsv` (spatial positions)
-
-Each row describes one spatial point or contact, identified by `nibs_position_id` and referenced from
-`nibs_position_id` in `*_events.tsv`. Multi-point constructs such as HD-tES montages, multi-coil setups,
-and multi-focus TUS are represented as multiple rows. The corresponding `*_events.tsv` row references
-them through a `|`-delimited `nibs_position_id`, ordered to match `nibs_element_id`. `position_group` MAY
-group related rows for organization only, never for linkage or synchronization. The coordinate frame and
-units are defined in `*_coordsystem.json`. Numeric fields are typed `number`.
-
-| Field | Type | Description |
-|---|---|---|
-| `nibs_position_id` | string | Identifier of a single point or contact (one row). MUST be unique within the file. |
-| `nibs_element_id` | string | Element (coil or electrode) at this position. Links to `nibs_element_id` in `*_nibs.tsv`, the same key that links `*_events.tsv` to `*_nibs.tsv`. |
-| `position_group` | string | (Optional) Organizational grouping label. MUST NOT be used for linkage or synchronization. |
-| `position_label` | string | (Optional) Standardized label (for example 10-20 `C3`, `F3`, or site labels `M1_hand`, `DLPFC`). |
-| `position_description` | string | (Optional) Free-text rationale or landmark description. |
-| `position_x` / `position_y` / `position_z` | number | Stimulation point (TMS cortical target, TUS acoustic focus, tES electrode site). |
-| `position_entry_x` / `_y` / `_z` | number | Entry point (tES scalp electrode position, TUS beam entry). |
-| `peeling_depth` | number | (Optional) Depth from the cortical surface or entry to the point. |
-| `position_coil_x` / `_y` / `_z` | number | (TMS) Coil origin location. |
-| `position_normal_x` / `_y` / `_z` | number | Coil or transducer normal vector. |
-| `position_direction_x` / `_y` / `_z` | number | (TMS) Coil direction vector. |
-| `position_beam_x` / `_y` / `_z` | number | (TUS) Beam-propagation direction vector. |
-| `position_transducer_x` / `_y` / `_z` | number | (TUS) Transducer centre. |
-| `position_coil_transform` / `position_transducer_transform` | array[number] | (Optional) 4x4 affine pose matrix. |
-| `position_efield_max_x` / `_y` / `_z` | number | (Optional) Location of the maximum electric field. |
-
-Field ordering follows function, from identification (`nibs_position_id`, `nibs_element_id`) to position
-(`position_*`, `position_entry_*`, `peeling_depth`, `position_coil_*` or `position_transducer_*`) to
-orientation and pose (`position_normal_*`, `position_direction_*`, `position_beam_*`,
-`position_*_transform`), and then to the optional field location. Basic datasets may include only
-`position_*` and `position_entry_*`, or only `position_label`. Advanced datasets add full pose and field
-modelling. A `*_markers.json` sidecar MAY describe these columns with units and descriptions.
+| Field | Requirement | Type | Description |
+|---|---|---|---|
+| `Navigation` | REQUIRED | boolean | Whether a navigation, tracking, or positioning system was used. |
+| `NavigationHardwareType` | RECOMMENDED | string | For example `optical_tracking`, `robot`, `cobot`, `mechanical_arm`. |
+| `NavigationModelName` | RECOMMENDED | string | Vendor or model. |
+| `NavigationSoftwareVersion` | OPTIONAL | string | Software version. |
+| `NavigationHardwareSerialNumber` | OPTIONAL | string | Serial number or identifier. |
+| `NavigationNotes` | OPTIONAL | string | Setup notes, for example camera type or calibration procedure. |
 
 ---
 
 ## `*_coordsystem.json` (coordinate metadata)
 
 Specifies the coordinate system, units, fiducials, and anatomical landmarks in which the positions in
-`*_markers.tsv` are expressed. Anatomical landmarks are locations on the participant such as the nasion.
-This file is REQUIRED for navigated TMS, tES, and TUS datasets. If a corresponding anatomical MRI is
-available, the locations of anatomical landmarks in that scan should also be stored in the `_T1w.json`
-file that accompanies it.
+`*_markers.tsv` are expressed. REQUIRED whenever `*_markers.tsv` contains coordinates. If a corresponding
+anatomical MRI is available, the locations of anatomical landmarks in that scan should also be stored in
+the `_T1w.json` file that accompanies it.
 
-| Field | Type | Description |
-|---|---|---|
-| `IntendedFor` | string | BIDS URI to the anatomical file this coordinate system refers to (for example `bids::sub-01/ses-01/anat/sub-01_T1w.nii.gz`). |
-| `NIBSCoordinateSystem` | string | Name of the coordinate system used for stimulation positions. Common values include `IndividualMRI`, `MNI152NLin2009cAsym`, and `CapTrak`. |
-| `NIBSCoordinateUnits` | string | Units used for coordinates in `*_markers.tsv`, typically `mm`. |
-| `NIBSCoordinateSystemDescription` | string | Free-text description of how the coordinate system was defined, including registration method and what the coordinates represent. |
-| `FiducialsDescription` | string | Free-text description of how fiducials were placed relative to anatomical landmarks and how their positions were measured. |
-| `FiducialsCoordinates` | object | Labels and 3D digitized positions of fiducials, interpreted in `FiducialsCoordinateSystem` (for example `{"NAS": [12.7,21.3,13.9], "LPA": [5.2,11.3,9.6], "RPA": [20.2,11.3,9.1]}`). Each array holds x, y, z in that order. |
-| `FiducialsCoordinateSystem` | string | Coordinate system for the fiducials, preferably the same as `NIBSCoordinateSystem`. |
-| `FiducialsCoordinateUnits` | string | Units for the fiducial coordinates. One of `m`, `mm`, `cm`, `n/a`. |
-| `FiducialsCoordinateSystemDescription` | string | Free-text description of the fiducial coordinate system. |
-| `AnatomicalLandmarkCoordinates` | object | Labels and 3D digitized locations of anatomical landmarks, interpreted in `AnatomicalLandmarkCoordinateSystem`. Each array holds x, y, z in that order. |
-| `AnatomicalLandmarkCoordinateSystem` | string | Coordinate system for the anatomical landmarks. If `Other`, define it in `AnatomicalLandmarkCoordinateSystemDescription`. |
-| `AnatomicalLandmarkCoordinateUnits` | string | Units of the landmark coordinates. One of `m`, `mm`, `cm`, `n/a`. |
-| `AnatomicalLandmarkCoordinateSystemDescription` | string | Free-text description of the landmark coordinate system. |
-| `AnatomicalLandmarkCoordinatesDescription` | string | Description of the landmark coordinates (NAS for nasion, LPA for left preauricular point, RPA for right preauricular point). |
-| `HeadMeasurements` | object | One or more head measurement vectors relevant for 10-20-based navigation. Each value is a numeric array. |
-| `HeadMeasurementsUnits` | string | Units for all values in `HeadMeasurements` (for example `mm`). |
-| `HeadMeasurementsDescription` | string | Free-text description of how the head measurements were obtained, including conventions. |
-| `DigitizedHeadPoints` | string | Relative path to the file with digitized head points (for example `sub-01_headshape.pos`). |
-| `DigitizedHeadPointsNumber` | integer | Number of digitized head points used during co-registration. |
-| `DigitizedHeadPointsDescription` | string | Free-text description of the digitized points. |
-| `DigitizedHeadPointsUnits` | string | Units. One of `m`, `mm`, `cm`, `n/a`. |
-| `AnatomicalLandmarkRmsDeviation` | object | Per-landmark deviation values, for example `{"RMS":[],"NAS":[],"LPA":[],"RPA":[]}`. |
-| `AnatomicalLandmarkRmsDeviationUnits` | string | Units of the RMS deviation values. |
-| `AnatomicalLandmarkRmsDeviationDescription` | string | Description of how the RMS deviation is calculated and for which markers. |
-
-For TUS datasets, when the spatial position or orientation of the transducer is known or fixed, the
-following optional fields complement the focus-location fields above. They support reproducible modelling
-and visualization of TUS targeting and acoustic beam propagation.
-
-| Field | Type | Description |
-|---|---|---|
-| `TransducerCoordinateUnits` | string | Units for transducer coordinates, typically `mm`. |
-| `TransducerCoordinateSystemDescription` | string | How the transducer coordinate system was defined and aligned with anatomy. |
-| `TransducerCoordinates` | object | Spatial coordinates of the transducer, and optionally a 4x4 affine transformation for its orientation. |
-| `TransducerCoordinatesDescription` | string | What the coordinates represent (for example transducer centre, entry point, beam axis). |
-| `TransducerRmsDeviation` | number | Root-mean-square deviation (mm) of the transducer position or orientation from the planned placement. |
-| `TransducerRmsDeviationUnits` | string | Units for the RMS deviation, consistent with the spatial units. |
-| `TransducerRmsDeviationDescription` | string | How the deviation was computed, what was measured, over what time frame, and by which method. |
-
----
-
-## Timeline and cross-modality interoperability (`*_events.tsv` / `*_events.json`)
-
-`*_events.tsv` is the primary experimental timeline used for synchronization across modalities.
-
-| Field | Type | Description |
-|---|---|---|
-| `onset` | number | Onset of the event (s). |
-| `duration` | number | Duration of the event (s), or `n/a` if not applicable. May be derived from the `*_nibs.tsv` pattern fields. |
-| `nibs_event_id` | string | References the matching `nibs_event_id` in `*_nibs.tsv` (the stimulation parameters). |
-| `nibs_position_id` | string | References `nibs_position_id` in `*_markers.tsv` (the stimulation position). May be `\|`-delimited, one position per element, in the same order as `nibs_element_id`. |
-
-`nibs_event_id` links each row to its parameter set in `*_nibs.tsv`, and `nibs_position_id` links it to
-its position or positions in `*_markers.tsv`. When NIBS is concurrent with a recorded modality, the
-timeline lives with that modality's `*_events.tsv`, and `*_nibs.json` points to it through `IntendedFor`.
-When NIBS is offline, meaning not concurrent with a recording, for example an fMRI run followed by tDCS
-followed by an fMRI run, or a behavioural block followed by TMS followed by a behavioural block,
-`*_events.tsv` is placed in `nibs/`, and the `*_nibs.tsv` is listed in `scans.tsv` between the
-surrounding recordings to mark the offline stimulation block.
-
-Because synchronization is carried entirely by shared event information, NIBS-BIDS is compatible with any
-concurrent or related recording modality that BIDS already describes. This includes EEG, MEG, fMRI, EMG,
-behavioural data, and intracranial electrophysiology such as iEEG, single-unit, and LFP recordings, when
-the stimulation itself is non-invasive. The recording modality is stored in its own BIDS datatype, and
-its `*_events.tsv` carries the same `nibs_event_id` values, so no NIBS-specific mechanism is required to
-combine stimulation with a recording. The list of modalities mentioned in this document and in the
-examples is illustrative and not a limit on compatibility.
+| Field | Requirement | Type | Description |
+|---|---|---|---|
+| `NIBSCoordinateSystem` | REQUIRED | string | Coordinate system used for the positions, for example `IndividualMRI`, `MNI152NLin2009cAsym`, or `CapTrak`. |
+| `NIBSCoordinateUnits` | REQUIRED | string | Units of the coordinates, typically `mm`. |
+| `NIBSCoordinateSystemDescription` | RECOMMENDED | string | How the coordinate system was defined, including the registration method and what the coordinates represent. |
+| `IntendedFor` | RECOMMENDED | string | BIDS URI to the anatomical file the coordinate system refers to, for example `bids::sub-01/anat/sub-01_T1w.nii.gz`. |
+| `FiducialsDescription` | OPTIONAL | string | How the fiducials were placed relative to anatomical landmarks and how their positions were measured. |
+| `FiducialsCoordinates` | OPTIONAL | object | Labels and 3D positions of the fiducials, each an array of x, y, z in that order. |
+| `FiducialsCoordinateSystem` | OPTIONAL | string | Coordinate system for the fiducials, preferably the same as `NIBSCoordinateSystem`. |
+| `FiducialsCoordinateUnits` | OPTIONAL | string | Units for the fiducial coordinates. One of `m`, `mm`, `cm`, `n/a`. |
+| `FiducialsCoordinateSystemDescription` | OPTIONAL | string | Description of the fiducial coordinate system. |
+| `AnatomicalLandmarkCoordinates` | OPTIONAL | object | Labels and 3D positions of anatomical landmarks, each an array of x, y, z in that order. |
+| `AnatomicalLandmarkCoordinateSystem` | OPTIONAL | string | Coordinate system for the anatomical landmarks. |
+| `AnatomicalLandmarkCoordinateUnits` | OPTIONAL | string | Units of the landmark coordinates. One of `m`, `mm`, `cm`, `n/a`. |
+| `AnatomicalLandmarkCoordinateSystemDescription` | OPTIONAL | string | Description of the landmark coordinate system. |
+| `AnatomicalLandmarkCoordinatesDescription` | OPTIONAL | string | Description of the landmarks, for example NAS for nasion, LPA and RPA for the preauricular points. |
+| `AnatomicalLandmarkRmsDeviation` | OPTIONAL | object | Per-landmark co-registration deviation values. |
+| `AnatomicalLandmarkRmsDeviationUnits` | OPTIONAL | string | Units of the deviation values. |
+| `AnatomicalLandmarkRmsDeviationDescription` | OPTIONAL | string | How the deviation was calculated and for which landmarks. |
+| `HeadMeasurements` | OPTIONAL | object | Head measurements taken with a tape from anatomical landmarks, used to locate elements without coordinates. Each value is a numeric array. |
+| `HeadMeasurementsUnits` | OPTIONAL | string | Units for all values in `HeadMeasurements`, for example `mm`. |
+| `HeadMeasurementsDescription` | OPTIONAL | string | How the measurements were obtained, including the landmarks used and any conventions. |
+| `DigitizedHeadPoints` | OPTIONAL | string | Relative path to the file with digitized head points, for example `sub-01_headshape.pos`. |
+| `DigitizedHeadPointsNumber` | OPTIONAL | number | Number of digitized head points used during co-registration. |
+| `DigitizedHeadPointsDescription` | OPTIONAL | string | Description of the digitized points. |
+| `DigitizedHeadPointsUnits` | OPTIONAL | string | Units. One of `m`, `mm`, `cm`, `n/a`. |
+| `TransducerCoordinates` | OPTIONAL | object | (TUS) Spatial coordinates of the transducer, and optionally an affine transformation for its orientation. |
+| `TransducerCoordinateUnits` | OPTIONAL | string | (TUS) Units for the transducer coordinates. |
+| `TransducerCoordinateSystemDescription` | OPTIONAL | string | (TUS) How the transducer coordinate system was defined and aligned with anatomy. |
+| `TransducerCoordinatesDescription` | OPTIONAL | string | (TUS) What the coordinates represent, for example transducer centre, entry point, or beam axis. |
+| `TransducerRmsDeviation` | OPTIONAL | number | (TUS) Deviation of the transducer position or orientation from the planned placement. |
+| `TransducerRmsDeviationUnits` | OPTIONAL | string | (TUS) Units for the deviation. |
+| `TransducerRmsDeviationDescription` | OPTIONAL | string | (TUS) How the deviation was computed and by which method. |
 
 ---
 
@@ -563,8 +573,8 @@ examples is illustrative and not a limit on compatibility.
 
 3D digitized head points that describe the head shape, and optionally EEG electrode locations, may be
 stored in a separate file. These points improve the accuracy of co-registration between the stimulation
-target and the anatomical data, and are useful when sharing datasets intended for electric-field
-modelling.
+element and the anatomical data, and are useful when sharing datasets intended for field modelling. They
+supplement the `DigitizedHeadPoints` fields in `*_coordsystem.json`.
 
 ```
 sub-<label>/
@@ -572,8 +582,6 @@ sub-<label>/
     └── nibs/
         └── sub-<label>[_ses-<label>]_task-<label>_acq-HEAD_headshape.pos
 ```
-
-These files supplement the `DigitizedHeadPoints` fields in the corresponding `_coordsystem.json`.
 
 ### Landmark photos (`*_photo.<ext>`)
 
@@ -598,13 +606,13 @@ https://github.com/nigelrogasch/nibs-bids/tree/master/nibs-bids-v6/examples/v.6.
 use cases:
 
 - Single- and paired-pulse TMS-EMG (SICI), including intensity references for the conditioning and test
-  pulses.
+  pulses, with placements given by 10-20 label rather than coordinates.
 - Theta-burst plasticity with concurrent TMS-EEG-EMG, recorded before and after an iTBS intervention,
   showing nested `pattern<index>` layers and offline stimulation.
 - Cortico-cortical paired associative stimulation (ccPAS) with two coils, shown as a `|`-delimited
-  `nibs_element_id` and as one row per coil, with positions in `*_markers.tsv`.
+  `nibs_element_id` and as one row per coil, with full element poses in `*_markers.tsv`.
 - tDCS with fMRI before and after, showing the simultaneous-electrode case and an offline timeline.
-- tACS and HD-tDCS montages, showing waveform parameters and multi-contact positions.
+- tACS and HD-tDCS montages, showing waveform parameters and multi-contact placements.
 
 ---
 
@@ -613,8 +621,8 @@ use cases:
 - Remove the `stimsys-<label>` filename entity and the `StimulationSystem` field; add the `nibs_type`
   column.
 - Replace `coil_id`, `electrode_id`, and `transducer_id` with `stimulator_id` and `nibs_element_id`, and
-  fold `CoilSet`, `ElectrodeSet`, and `TransducerSet` into one `ElementSet` (`ElementType`) with a
-  separate `StimulatorSet`.
+  fold `CoilSet`, `ElectrodeSet`, and `TransducerSet` into one `ElementSet` with a separate
+  `StimulatorSet`.
 - Replace the `StimulusSet` templates and the `stim_id` reference with per-row `stimulus_*` fields and
   `pattern<index>_*` layers in `*_nibs.tsv`.
 - Move shape-specific parameters out of JSON `Levels` into `*_nibs.tsv` columns (`first_inflection`,
@@ -623,8 +631,11 @@ use cases:
   `stimulus_intensity`, or one row per element.
 - Replace the `threshold_*` fields with `intensity_reference` and `intensity_scaling`, and move the
   reference value into an `IntensitySet` block.
-- Rename `target_id` to `nibs_position_id`, move it from `*_nibs.tsv` into `*_events.tsv`, rename the
-  `*_markers.tsv` spatial columns to `position_*`, and add `nibs_element_id` to `*_markers.tsv`.
+- Rename `target_id` to `nibs_position_id` and move it from `*_nibs.tsv` into `*_events.tsv`.
+- Replace the separate `coil_*` and `transducer_*` centres and the `normal_*`, `direction_*`, and
+  `beam_*` vectors with one `element_centre_*` and the three `element_xdir_*`, `element_ydir_*`, and
+  `element_zdir_*` axes. Coordinates that described a cortical target rather than an element move to the
+  optional `target_*` columns.
 - Prefix the cross-file linkage keys with `nibs_` (`nibs_event_id`, `nibs_position_id`,
   `nibs_element_id`).
 - Type numeric fields as `number` rather than `integer`, and declare units per column in `*_nibs.json`.

--- a/nibs-bids-v6/examples/v.6.3/ccpas-tms_GB/coil1-coil2/sub-001/nibs/sub-001_task-rest_acq-ccPAS_coordsystem.json
+++ b/nibs-bids-v6/examples/v.6.3/ccpas-tms_GB/coil1-coil2/sub-001/nibs/sub-001_task-rest_acq-ccPAS_coordsystem.json
@@ -1,5 +1,5 @@
 {
   "NIBSCoordinateSystem": "MNI152NLin2009cAsym",
   "NIBSCoordinateUnits": "mm",
-  "NIBSCoordinateSystemDescription": "Stimulation targets were defined with frameless neuronavigation and are reported in standard MNI152NLin2009cAsym space. position_x/y/z give the cortical target of each coil in this space."
+  "NIBSCoordinateSystemDescription": "Element placements and targets were defined with frameless neuronavigation and are reported in standard MNI152NLin2009cAsym space. element_centre_x/y/z give the centre of each coil on the head, the element_xdir/ydir/zdir columns give its axes, and target_x/y/z give the intended cortical target."
 }

--- a/nibs-bids-v6/examples/v.6.3/ccpas-tms_GB/coil1-coil2/sub-001/nibs/sub-001_task-rest_acq-ccPAS_markers.json
+++ b/nibs-bids-v6/examples/v.6.3/ccpas-tms_GB/coil1-coil2/sub-001/nibs/sub-001_task-rest_acq-ccPAS_markers.json
@@ -1,33 +1,84 @@
 {
   "nibs_position_id": {
     "LongName": "Position identifier",
-    "Description": "Identifier of a single stimulation position (one row). Referenced from nibs_position_id in *_events.tsv. MUST be unique within this file."
+    "Description": "Identifier of one element placement (one row). Referenced from nibs_position_id in *_events.tsv. MUST be unique within this file."
   },
   "nibs_element_id": {
     "LongName": "Element identifier",
-    "Description": "Element (coil/electrode) located at this position. Links to nibs_element_id in *_nibs.tsv (same key that links *_events.tsv to *_nibs.tsv)."
+    "Description": "Element placed at this position. Links to nibs_element_id in *_nibs.tsv."
   },
   "position_label": {
     "LongName": "Position label",
-    "Description": "Standardized site label."
+    "Description": "Standardized label for the placement."
   },
   "position_description": {
     "LongName": "Position description",
-    "Description": "Free-text description of the position / role in the protocol."
+    "Description": "Free-text description of the placement and how it was located."
   },
-  "position_x": {
-    "LongName": "Position x",
-    "Description": "x coordinate of the stimulation site in the coordinate system declared in *_coordsystem.json.",
+  "element_centre_x": {
+    "LongName": "Element centre x",
+    "Description": "x component of the centre of the element.",
     "Units": "mm"
   },
-  "position_y": {
-    "LongName": "Position y",
-    "Description": "y coordinate of the stimulation site.",
+  "element_centre_y": {
+    "LongName": "Element centre y",
+    "Description": "y component of the centre of the element.",
     "Units": "mm"
   },
-  "position_z": {
-    "LongName": "Position z",
-    "Description": "z coordinate of the stimulation site.",
+  "element_centre_z": {
+    "LongName": "Element centre z",
+    "Description": "z component of the centre of the element.",
+    "Units": "mm"
+  },
+  "element_xdir_x": {
+    "LongName": "Element xdir x",
+    "Description": "x component of the element x axis. Unit vector; the three axes are mutually orthogonal and right-handed (xdir = ydir x zdir)."
+  },
+  "element_xdir_y": {
+    "LongName": "Element xdir y",
+    "Description": "y component of the element x axis. Unit vector; the three axes are mutually orthogonal and right-handed (xdir = ydir x zdir)."
+  },
+  "element_xdir_z": {
+    "LongName": "Element xdir z",
+    "Description": "z component of the element x axis. Unit vector; the three axes are mutually orthogonal and right-handed (xdir = ydir x zdir)."
+  },
+  "element_ydir_x": {
+    "LongName": "Element ydir x",
+    "Description": "x component of the element y axis, running along the handle. Unit vector; the three axes are mutually orthogonal and right-handed (xdir = ydir x zdir)."
+  },
+  "element_ydir_y": {
+    "LongName": "Element ydir y",
+    "Description": "y component of the element y axis, running along the handle. Unit vector; the three axes are mutually orthogonal and right-handed (xdir = ydir x zdir)."
+  },
+  "element_ydir_z": {
+    "LongName": "Element ydir z",
+    "Description": "z component of the element y axis, running along the handle. Unit vector; the three axes are mutually orthogonal and right-handed (xdir = ydir x zdir)."
+  },
+  "element_zdir_x": {
+    "LongName": "Element zdir x",
+    "Description": "x component of the element z axis, pointing from the element into the head. Unit vector; the three axes are mutually orthogonal and right-handed (xdir = ydir x zdir)."
+  },
+  "element_zdir_y": {
+    "LongName": "Element zdir y",
+    "Description": "y component of the element z axis, pointing from the element into the head. Unit vector; the three axes are mutually orthogonal and right-handed (xdir = ydir x zdir)."
+  },
+  "element_zdir_z": {
+    "LongName": "Element zdir z",
+    "Description": "z component of the element z axis, pointing from the element into the head. Unit vector; the three axes are mutually orthogonal and right-handed (xdir = ydir x zdir)."
+  },
+  "target_x": {
+    "LongName": "Target x",
+    "Description": "x coordinate of the intended cortical target. Optional and secondary to the element placement.",
+    "Units": "mm"
+  },
+  "target_y": {
+    "LongName": "Target y",
+    "Description": "y coordinate of the intended cortical target. Optional and secondary to the element placement.",
+    "Units": "mm"
+  },
+  "target_z": {
+    "LongName": "Target z",
+    "Description": "z coordinate of the intended cortical target. Optional and secondary to the element placement.",
     "Units": "mm"
   }
 }

--- a/nibs-bids-v6/examples/v.6.3/ccpas-tms_GB/coil1-coil2/sub-001/nibs/sub-001_task-rest_acq-ccPAS_markers.tsv
+++ b/nibs-bids-v6/examples/v.6.3/ccpas-tms_GB/coil1-coil2/sub-001/nibs/sub-001_task-rest_acq-ccPAS_markers.tsv
@@ -1,3 +1,3 @@
-nibs_position_id	nibs_element_id	position_label	position_description	position_x	position_y	position_z
-PMv_L	Coil_1	left PMv	Left ventral premotor cortex (conditioning site)	-52	8	28
-M1_L	Coil_2	left M1 (FDI)	Left primary motor cortex, FDI hotspot (test site)	-37	-21	58
+nibs_position_id	nibs_element_id	position_label	position_description	element_centre_x	element_centre_y	element_centre_z	element_xdir_x	element_xdir_y	element_xdir_z	element_ydir_x	element_ydir_y	element_ydir_z	element_zdir_x	element_zdir_y	element_zdir_z	target_x	target_y	target_z
+PMv_L	Coil_1	left PMv	Left ventral premotor cortex (conditioning site)	-65.0875	15.0471	30.0135	0.1521	0.0	0.9884	-0.4643	-0.8828	0.0714	0.8725	-0.4698	-0.1342	-52.0	8.0	28.0
+M1_L	Coil_2	left M1 (FDI)	Left primary motor cortex, FDI hotspot (test site)	-47.4624	-21.2828	68.7452	0.7165	0.0	0.6976	0.0132	-0.9998	-0.0135	0.6975	0.0189	-0.7163	-37.0	-21.0	58.0

--- a/nibs-bids-v6/examples/v.6.3/ccpas-tms_GB/two-rows/sub-001/nibs/sub-001_task-rest_acq-ccPAS_coordsystem.json
+++ b/nibs-bids-v6/examples/v.6.3/ccpas-tms_GB/two-rows/sub-001/nibs/sub-001_task-rest_acq-ccPAS_coordsystem.json
@@ -1,5 +1,5 @@
 {
   "NIBSCoordinateSystem": "MNI152NLin2009cAsym",
   "NIBSCoordinateUnits": "mm",
-  "NIBSCoordinateSystemDescription": "Stimulation targets were defined with frameless neuronavigation and are reported in standard MNI152NLin2009cAsym space. position_x/y/z give the cortical target of each coil in this space."
+  "NIBSCoordinateSystemDescription": "Element placements and targets were defined with frameless neuronavigation and are reported in standard MNI152NLin2009cAsym space. element_centre_x/y/z give the centre of each coil on the head, the element_xdir/ydir/zdir columns give its axes, and target_x/y/z give the intended cortical target."
 }

--- a/nibs-bids-v6/examples/v.6.3/ccpas-tms_GB/two-rows/sub-001/nibs/sub-001_task-rest_acq-ccPAS_markers.json
+++ b/nibs-bids-v6/examples/v.6.3/ccpas-tms_GB/two-rows/sub-001/nibs/sub-001_task-rest_acq-ccPAS_markers.json
@@ -1,33 +1,84 @@
 {
   "nibs_position_id": {
     "LongName": "Position identifier",
-    "Description": "Identifier of a single stimulation position (one row). Referenced from nibs_position_id in *_events.tsv. MUST be unique within this file."
+    "Description": "Identifier of one element placement (one row). Referenced from nibs_position_id in *_events.tsv. MUST be unique within this file."
   },
   "nibs_element_id": {
     "LongName": "Element identifier",
-    "Description": "Element (coil/electrode) located at this position. Links to nibs_element_id in *_nibs.tsv (same key that links *_events.tsv to *_nibs.tsv)."
+    "Description": "Element placed at this position. Links to nibs_element_id in *_nibs.tsv."
   },
   "position_label": {
     "LongName": "Position label",
-    "Description": "Standardized site label."
+    "Description": "Standardized label for the placement."
   },
   "position_description": {
     "LongName": "Position description",
-    "Description": "Free-text description of the position / role in the protocol."
+    "Description": "Free-text description of the placement and how it was located."
   },
-  "position_x": {
-    "LongName": "Position x",
-    "Description": "x coordinate of the stimulation site in the coordinate system declared in *_coordsystem.json.",
+  "element_centre_x": {
+    "LongName": "Element centre x",
+    "Description": "x component of the centre of the element.",
     "Units": "mm"
   },
-  "position_y": {
-    "LongName": "Position y",
-    "Description": "y coordinate of the stimulation site.",
+  "element_centre_y": {
+    "LongName": "Element centre y",
+    "Description": "y component of the centre of the element.",
     "Units": "mm"
   },
-  "position_z": {
-    "LongName": "Position z",
-    "Description": "z coordinate of the stimulation site.",
+  "element_centre_z": {
+    "LongName": "Element centre z",
+    "Description": "z component of the centre of the element.",
+    "Units": "mm"
+  },
+  "element_xdir_x": {
+    "LongName": "Element xdir x",
+    "Description": "x component of the element x axis. Unit vector; the three axes are mutually orthogonal and right-handed (xdir = ydir x zdir)."
+  },
+  "element_xdir_y": {
+    "LongName": "Element xdir y",
+    "Description": "y component of the element x axis. Unit vector; the three axes are mutually orthogonal and right-handed (xdir = ydir x zdir)."
+  },
+  "element_xdir_z": {
+    "LongName": "Element xdir z",
+    "Description": "z component of the element x axis. Unit vector; the three axes are mutually orthogonal and right-handed (xdir = ydir x zdir)."
+  },
+  "element_ydir_x": {
+    "LongName": "Element ydir x",
+    "Description": "x component of the element y axis, running along the handle. Unit vector; the three axes are mutually orthogonal and right-handed (xdir = ydir x zdir)."
+  },
+  "element_ydir_y": {
+    "LongName": "Element ydir y",
+    "Description": "y component of the element y axis, running along the handle. Unit vector; the three axes are mutually orthogonal and right-handed (xdir = ydir x zdir)."
+  },
+  "element_ydir_z": {
+    "LongName": "Element ydir z",
+    "Description": "z component of the element y axis, running along the handle. Unit vector; the three axes are mutually orthogonal and right-handed (xdir = ydir x zdir)."
+  },
+  "element_zdir_x": {
+    "LongName": "Element zdir x",
+    "Description": "x component of the element z axis, pointing from the element into the head. Unit vector; the three axes are mutually orthogonal and right-handed (xdir = ydir x zdir)."
+  },
+  "element_zdir_y": {
+    "LongName": "Element zdir y",
+    "Description": "y component of the element z axis, pointing from the element into the head. Unit vector; the three axes are mutually orthogonal and right-handed (xdir = ydir x zdir)."
+  },
+  "element_zdir_z": {
+    "LongName": "Element zdir z",
+    "Description": "z component of the element z axis, pointing from the element into the head. Unit vector; the three axes are mutually orthogonal and right-handed (xdir = ydir x zdir)."
+  },
+  "target_x": {
+    "LongName": "Target x",
+    "Description": "x coordinate of the intended cortical target. Optional and secondary to the element placement.",
+    "Units": "mm"
+  },
+  "target_y": {
+    "LongName": "Target y",
+    "Description": "y coordinate of the intended cortical target. Optional and secondary to the element placement.",
+    "Units": "mm"
+  },
+  "target_z": {
+    "LongName": "Target z",
+    "Description": "z coordinate of the intended cortical target. Optional and secondary to the element placement.",
     "Units": "mm"
   }
 }

--- a/nibs-bids-v6/examples/v.6.3/ccpas-tms_GB/two-rows/sub-001/nibs/sub-001_task-rest_acq-ccPAS_markers.tsv
+++ b/nibs-bids-v6/examples/v.6.3/ccpas-tms_GB/two-rows/sub-001/nibs/sub-001_task-rest_acq-ccPAS_markers.tsv
@@ -1,3 +1,3 @@
-nibs_position_id	nibs_element_id	position_label	position_description	position_x	position_y	position_z
-PMv_L	Coil_1	left PMv	Left ventral premotor cortex (conditioning site)	-52	8	28
-M1_L	Coil_2	left M1 (FDI)	Left primary motor cortex, FDI hotspot (test site)	-37	-21	58
+nibs_position_id	nibs_element_id	position_label	position_description	element_centre_x	element_centre_y	element_centre_z	element_xdir_x	element_xdir_y	element_xdir_z	element_ydir_x	element_ydir_y	element_ydir_z	element_zdir_x	element_zdir_y	element_zdir_z	target_x	target_y	target_z
+PMv_L	Coil_1	left PMv	Left ventral premotor cortex (conditioning site)	-65.0875	15.0471	30.0135	0.1521	0.0	0.9884	-0.4643	-0.8828	0.0714	0.8725	-0.4698	-0.1342	-52.0	8.0	28.0
+M1_L	Coil_2	left M1 (FDI)	Left primary motor cortex, FDI hotspot (test site)	-47.4624	-21.2828	68.7452	0.7165	0.0	0.6976	0.0132	-0.9998	-0.0135	0.6975	0.0189	-0.7163	-37.0	-21.0	58.0

--- a/nibs-bids-v6/examples/v.6.3/motor-tms-emg_GB/README.md
+++ b/nibs-bids-v6/examples/v.6.3/motor-tms-emg_GB/README.md
@@ -1,83 +1,29 @@
-# Notes — 2026-06-16 (meeting with Nigel)
+# Example data set: motor TMS-EMG (SICI)
 
-Decisions from the 2026-06-16 meeting and subsequent clarification. These replace the earlier
-`ThresholdSet` / `threshold_*` fields. The general structure is considered settled; the ccPAS
-double-coil case is treated as an edge case and is not a prerequisite for the general model.
+Single- and paired-pulse TMS with concurrent EMG, formatted to the NIBS-BIDS v6.3 structure. One
+acquisition interleaves single test pulses (`spTMS`) and paired conditioning-test pulses (`SICI`, 2 ms
+inter-stimulus interval). TMS is delivered over left primary motor cortex and EMG is recorded from the
+right first dorsal interosseous.
 
-## Intensity fields
-- `stimulus_intensity` is retained as the delivered amplitude. `intensity_reference` and
-  `intensity_scaling` record how that amplitude was set.
-- `intensity_reference` (TSV): closed vocabulary, e.g. `rMT`, `aMT`, `1mV`, `e-field`, `absolute`.
-- `intensity_scaling` (TSV): a number (e.g. `0.8`) or `absolute` (value given directly, no scaling).
-- Both may be `|`-delimited and are aligned position-by-position, e.g.
-  `intensity_reference = rMT|1mV|e-field` with `intensity_scaling = 0.8|1|absolute`.
-- The reference value is not stored in the TSV. It is given in the JSON `IntensitySet` entry as
-  `Value` (e.g. rMT = 50 %MSO), since it is constant within a file.
-- `absolute` may appear as an `intensity_reference` value as well as an `intensity_scaling` value.
-- When intensity varies between pulses, the per-pulse values are in `pattern1_intensity` and
-  `stimulus_intensity` is `n/a` (unchanged from SICI).
+Resting motor threshold (rMT) is 50 % maximum stimulator output and the 1 mV test intensity is 58 %,
+both recorded in the `IntensitySet` block of `*_nibs.json`. The conditioning pulse is dosed at 70% rMT
+(35 %) and the test pulse at the 1 mV intensity.
 
-## IntensitySet (JSON)
-- `ThresholdSet` is renamed `IntensitySet`. Each entry: `IntensityID`, `Value`, `Units`, and method
-  fields (`Type`, `Criterion`, `Algorithm`, `MeasurementMethod`). Referenced by `intensity_reference`.
+## What this example shows
 
-## Temporal and spatial description
-- Temporal structure is given by `nibs.tsv` (`stimulus_*`, `pattern<n>_*`).
-- Spatial structure is given by `markers.tsv`.
-
-## Positions
-- `target_id` is renamed `nibs_position_id`.
-- `nibs_position_id` is placed in `events.tsv` alongside `nibs_event_id`: `nibs_event_id` references `nibs.tsv`,
-  `nibs_position_id` references `markers.tsv`.
-- `nibs_position_id` may be `|`-delimited, one position per element.
-- Spatial columns in `markers.tsv` are renamed `target_*` / `coil_*` -> `position_*`.
-
-## Offline / behavioural experiments
-- When stimulation is not concurrent with a recording (e.g. beh, TMS, beh), `events.tsv` is placed in
-  `nibs/`. `scans.tsv` lists `beh.tsv`, `nibs.tsv`, `beh.tsv`; the `nibs.tsv` entry denotes an offline
-  stimulation block.
-
-## ccPAS (double coil)
-- Modelled as SICI: one `nibs.tsv` row, `pattern1` of 2 pulses at the intra-pair interval, the two coil
-  intensities in `pattern1_intensity`, `stimulus_intensity = n/a`.
-- `nibs_element_id = double_coil`, expanded in the JSON `ElementSet`; `coil_1|coil_2` is an equivalent form.
-- `events.tsv` carries one trigger per pair.
-- `nibs_position_id` references two positions (one per coil), `|`-delimited.
-
-## Tool (future)
-- A description of a pulse sequence could be extended to higher-order sequences: acquisition order,
-  recording order (`scans.tsv`), session order (`sessions.tsv`).
-
-Status: applied to the `_GB` examples on 2026-06-16.
-
----
-
-> [!IMPORTANT]
-> ## Delimiter `|` — meaning by column
->
-> - `pattern<n>_intensity`: successive stimuli over time (in order); the number of values equals
->   `pattern<n>_count`. When intensity changes between pulses, `stimulus_intensity = n/a` and the
->   per-pulse values go here. SICI: `35|58` = conditioning then test. Two coils fired sequentially
->   (e.g. ccPAS) are also a time vector and go here, not in `stimulus_intensity`.
-> - `stimulus_intensity`, `nibs_element_id`, `nibs_position_id`: multiple elements at the same instant (e.g.
->   simultaneous tES electrodes; for tES the values sum to 0). `stimulus_intensity` is always the
->   delivered amplitude; `intensity_reference` / `intensity_scaling` describe how it was set.
-> - Any column using `|` declares its delimiter in the `*_nibs.json` sidecar.
-
-# Example data set: motor TMS-EMG (SICI) — GB working copy
-
-Working copy (`_GB`) of the `motor-tms-emg` example in the proposed NIBS-BIDS v6.3 structure with the
-2026-06-16 decisions applied: stimulus parameters in `*_nibs.tsv`, intensity references described in an
-`IntensitySet` block in `*_nibs.json`, and positions in `*_markers.tsv` referenced from `*_events.tsv`.
-
-## Experiment details
-TMS-EMG data from a single individual. One acquisition: SICI (short-interval intracortical inhibition),
-interleaving single test pulses (`spTMS`) and paired conditioning-test pulses (`SICI`, 2 ms ISI). TMS over
-left primary motor cortex; EMG from the right first dorsal interosseous. Resting motor threshold
-rMT = 50 %MSO; the test pulse intensity (`1mV`) = 58 %MSO. Conditioning pulse = 70% rMT (35 %MSO).
+- Two intensity references in one row. The `SICI` row carries `pattern1_intensity = 35|58` with
+  `intensity_reference = rMT|1mV` and `intensity_scaling = 0.7|1`, so each pulse records how its
+  amplitude was chosen.
+- A paired pulse described with `pattern1` rather than two rows, with `stimulus_intensity = n/a`
+  because the per-pulse values are in `pattern1_intensity`.
+- Placement given without coordinates. `*_markers.tsv` locates the coil by `position_label` (`C3`) and
+  `position_description` alone, which is the usual case for non-navigated motor TMS.
+- Concurrent EMG. The timeline lives in `emg/*_events.tsv` and `*_nibs.json` points to it through
+  `IntendedFor`.
 
 ## Files
-- `nibs/*_nibs.tsv` / `.json`: stimulation parameters and `IntensitySet`.
-- `nibs/*_markers.tsv` / `.json`: stimulation position(s).
-- `emg/*_events.tsv` / `.json`: timeline (`nibs_event_id` -> `nibs.tsv`, `nibs_position_id` -> `markers.tsv`).
-- `emg/*_emg.mat`: empty placeholder, demonstration only.
+
+- `nibs/*_nibs.tsv` and `.json`: temporal parameters, `StimulatorSet`, `ElementSet`, `IntensitySet`.
+- `nibs/*_markers.tsv` and `.json`: coil placement.
+- `emg/*_events.tsv` and `.json`: timeline (`nibs_event_id`, `nibs_position_id`).
+- `emg/*_emg.mat`: empty placeholder, included for demonstration only.


### PR DESCRIPTION
notes: 

make clearer the distinction between temporal info in nibs.tsv and spatial info in marker.tsv (double check)
make tables only for TSV stuff. definition not in a table. (basically like in any other BIDS specification)
move event file description further up (as it links with others, so might be logically better to have it up).
postion: first describe the position of the element (we are describing primarly the postion of the coil/trnsudcer on the head), and furhter down descrive optionally the cpostion of the target (which is not the primary focus here).
postion: how to reconstruct the postion matrix (4 x 4 , with row and cols that are 0s 3 x3 ) from this specificaion and vice versa? make sure that is clear. look at one of the eralier versions we had that transformation matrix ? we have to resolve this https://simnibs.github.io/simnibs/build/html/documentation/sim_struct/position.html . 3 rows, coodinate for the 3 coil (element) axis. the center of the element is the last column
postion: collapse coil/transducer/electrod center to element centre.
postion: we need to be able to describ postion with "less" tecnical ways like: for TMS using elec postions or head measurament made with tape ruler (nasion, inion, etc.. ), but maybe we alredy ahve a text description?